### PR TITLE
fix: fix minigpt-env wrong torch deps

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,14 +3,15 @@ channels:
   - pytorch
   - defaults
   - anaconda
+  - nvidia
 dependencies:
   - python=3.9
   - cudatoolkit
   - pip
-  - pytorch=1.12.1
+  - pytorch=1.13.1
   - pytorch-mutex=1.0=cuda
-  - torchaudio=0.12.1
-  - torchvision=0.13.1
+  - torchaudio=0.13.1
+  - torchvision=0.14.1
   - pip:
     - accelerate==0.16.0
     - aiohttp==3.8.4


### PR DESCRIPTION
It seems that conda torch 1.12 will be overrided by pip torch 2.0 due to peft requires torch 1.13
So I changes the torch version to 1.13.1 and torchvision to 0.14.1
I have tested it works well on kubuntu 22.04 + driver 530