### PR TITLE
bug: fix warmup LR

### DIFF
--- a/minigpt4/common/optims.py
+++ b/minigpt4/common/optims.py
@@ -80,7 +80,7 @@ class LinearWarmupCosineLRScheduler:
         total_cur_step = cur_epoch * self.iters_per_epoch + cur_step
         if total_cur_step < self.warmup_steps:
             warmup_lr_schedule(
-                step=cur_step,
+                step=total_cur_step,
                 optimizer=self.optimizer,
                 max_step=self.warmup_steps,
                 init_lr=self.warmup_start_lr,


### PR DESCRIPTION
LR resets every epoch during warmup to `warmup_start_lr` because it uses inner epoch step counter. We need to use `total_cur_step` to increment LR continuously from epoch to epoch.