### PR TITLE
Update image download size

### DIFF
--- a/dataset/download_cc_sbu.sh
+++ b/dataset/download_cc_sbu.sh
@@ -2,5 +2,5 @@
 
 img2dataset --url_list ccs_synthetic_filtered_large.tsv --input_format "tsv"\
          --url_col "url" --caption_col "caption" --output_format webdataset\
-           --output_folder cc_sbu_dataset --processes_count 16 --thread_count 128 --image_size 256 \
+           --output_folder cc_sbu_dataset --processes_count 16 --thread_count 128 --image_size 224 \
              --enable_wandb True

--- a/dataset/download_laion.sh
+++ b/dataset/download_laion.sh
@@ -2,5 +2,5 @@
 
 img2dataset --url_list laion_synthetic_filtered_large.tsv --input_format "tsv"\
          --url_col "url" --caption_col "caption" --output_format webdataset\
-           --output_folder laion_dataset --processes_count 16 --thread_count 128 --image_size 256 \
+           --output_folder laion_dataset --processes_count 16 --thread_count 128 --image_size 224 \
              --enable_wandb True


### PR DESCRIPTION
The training set up assumes 224x224 images whereas the current scripts download 256x256. This change allows the datasets to be downloaded in the expected format as well as significantly decrease the final dataset size.