### PR TITLE
Fix model and image size mismatch message

### DIFF
--- a/minigpt4/models/eva_vit.py
+++ b/minigpt4/models/eva_vit.py
@@ -199,7 +199,7 @@ class PatchEmbed(nn.Module):
         B, C, H, W = x.shape
         # FIXME look at relaxing size constraints
         assert H == self.img_size[0] and W == self.img_size[1], \
-            f"Input image size ({H}*{W}) doesn't match model ({self.img_size[0]}*{self.img_size[1]})."
+            f"Input image size ({self.img_size[0]}*{self.img_size[1]}) doesn't match model ({H}*{W})."
         x = self.proj(x).flatten(2).transpose(1, 2)
         return x
 


### PR DESCRIPTION
When this assertion failed, the error message produced was backwards. For example, feeding a 256x256 image into a 224x224 size model during second-stage finetuning yielded `"Input image size (224*224) doesn't match model (256x256)." This change fixes this and will hopefully help newcomers with debugging second-stage finetuning.