### PR TITLE
Drastically improved load speed of llama when low_resource=False

### DIFF
--- a/minigpt4/models/mini_gpt4.py
+++ b/minigpt4/models/mini_gpt4.py
@@ -118,6 +118,7 @@ class MiniGPT4(Blip2Base):
             self.llama_model = LlamaForCausalLM.from_pretrained(
                 llama_model,
                 torch_dtype=torch.float16,
+                low_cpu_mem_usage=True,
             )
 
         if lora_r > 0:


### PR DESCRIPTION
Added an argument `low_cpu_mem_usage=True` that drastically reduces load time of the model.  Before I made this change, loading Llama took more than a minute.  Now it loads in seconds.

Tested on NVIDIA 4090 Founder's Edition.