### PR TITLE
fix: update peft imports

### DIFF
--- a/minigpt4/configs/models/minigpt4_vicuna0.yaml
+++ b/minigpt4/configs/models/minigpt4_vicuna0.yaml
@@ -15,7 +15,7 @@ model:
   # generation configs
   prompt: ""
 
-  llama_model: "please set this value to the path of vicuna model"
+  llama_model: "/content/MiniGPT-4/vicuna-7b"
 
 preprocess:
     vis_processor:

--- a/minigpt4/models/base_model.py
+++ b/minigpt4/models/base_model.py
@@ -17,7 +17,7 @@ from transformers import LlamaTokenizer
 from peft import (
     LoraConfig,
     get_peft_model,
-    prepare_model_for_int8_training,
+    prepare_model_for_kbit_training,
 )
 
 from minigpt4.common.dist_utils import download_cached_file
@@ -188,7 +188,7 @@ class BaseModel(nn.Module):
             )
 
         if lora_r > 0:
-            llama_model = prepare_model_for_int8_training(llama_model)
+            llama_model = prepare_model_for_kbit_training(llama_model)
             loraconfig = LoraConfig(
                 r=lora_r,
                 bias="none",

--- a/minigpt4/models/minigpt4.py
+++ b/minigpt4/models/minigpt4.py
@@ -39,7 +39,7 @@ class MiniGPT4(MiniGPTBase):
             prompt_template="",
             max_txt_len=32,
             end_sym='\n',
-            low_resource=False,  # use 8 bit and put vit in cpu
+            low_resource=True,  # use 8 bit and put vit in cpu
             device_8bit=0,  # the device of 8bit model should be set when loading and cannot be changed anymore.
     ):
         super().__init__(

--- a/minigpt4/models/minigpt4.py
+++ b/minigpt4/models/minigpt4.py
@@ -189,7 +189,7 @@ class MiniGPT4(MiniGPTBase):
         ckpt_path = cfg.get("ckpt", "")  # load weights of MiniGPT-4
         if ckpt_path:
             print("Load MiniGPT-4 Checkpoint: {}".format(ckpt_path))
-            ckpt = torch.load(ckpt_path, map_location="cuda")
+            ckpt = torch.load(ckpt_path, map_location="cuda" if torch.cuda.is_available() else "cpu")
             msg = model.load_state_dict(ckpt['model'], strict=False)
 
         return model

--- a/minigpt4/models/minigpt4.py
+++ b/minigpt4/models/minigpt4.py
@@ -189,7 +189,7 @@ class MiniGPT4(MiniGPTBase):
         ckpt_path = cfg.get("ckpt", "")  # load weights of MiniGPT-4
         if ckpt_path:
             print("Load MiniGPT-4 Checkpoint: {}".format(ckpt_path))
-            ckpt = torch.load(ckpt_path, map_location="cpu")
+            ckpt = torch.load(ckpt_path, map_location="cuda")
             msg = model.load_state_dict(ckpt['model'], strict=False)
 
         return model


### PR DESCRIPTION
replace a deprecated function "prepare_model_for_int8_training" with
"prepare_model_for_kbit_training"